### PR TITLE
Fix deprecation warning from Thor

### DIFF
--- a/lib/active_model/serializer/generators/serializer/scaffold_controller_generator.rb
+++ b/lib/active_model/serializer/generators/serializer/scaffold_controller_generator.rb
@@ -7,7 +7,7 @@ module Rails
       if Rails::VERSION::MAJOR >= 4
         source_root File.expand_path('../templates', __FILE__)
 
-        hook_for :serializer, default: true
+        hook_for :serializer, default: true, type: :boolean
       end
     end
   end


### PR DESCRIPTION
```
Deprecation warning: Expected string default value for '--serializer'; got true (boolean).
This will be rejected in the future unless you explicitly pass the options `check_default_type: false` or call `allow_incompatible_default_type!` in your code
You can silence deprecations warning by setting the environment variable THOR_SILENCE_DEPRECATION
```